### PR TITLE
Adding dumb-init

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,9 +5,11 @@ MAINTAINER Joeri Verdeyen <joeriv@yappa.be>
 ENV HTTP_PORT 1080
 ENV SMTP_PORT 1025
 
+
 RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -q -y \
     libsqlite3-dev \
+    wget \
     ruby \
     ruby-dev \
     build-essential && \
@@ -17,10 +19,13 @@ RUN apt-get update && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists
 
+RUN wget -O /usr/local/bin/dumb-init https://github.com/Yelp/dumb-init/releases/download/v1.2.1/dumb-init_1.2.1_amd64 && chmod +x /usr/local/bin/dumb-init
+
 RUN echo Europe/Brussels > /etc/timezone && dpkg-reconfigure --frontend noninteractive tzdata
 
 EXPOSE 1080 1025
 
 COPY run.sh /run.sh
 RUN chmod +x /run.sh
+ENTRYPOINT ["/usr/local/bin/dumb-init", "--"]
 CMD ["/run.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,6 @@ MAINTAINER Joeri Verdeyen <joeriv@yappa.be>
 ENV HTTP_PORT 1080
 ENV SMTP_PORT 1025
 
-
 RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -q -y \
     libsqlite3-dev \


### PR DESCRIPTION
This allows it to run a bit better, especially properly handle exit signals instead of needing to be force killed.

Every docker image should use proper init handling - this PR adds a transparent one which doesn't affect the operation but adds proper init functionality.