### PR TITLE
Adding curl

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,8 @@ ENV SMTP_PORT 1025
 RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -q -y \
     libsqlite3-dev \
-    ruby \
+    curl \
+    ruby \    
     ruby-dev \
     build-essential && \
     gem install --no-ri --no-rdoc mailcatcher && \


### PR DESCRIPTION
Adding curl allows better healthchecks as part of a larger environment.

For example, in this section in my `docker-compose.yml` file, adding curl to the container allows the docker orchestrator to report on if the app is up or down, and take action.

```
  # Mock mail server and viewer
  mail:
    image: yappabe/mailcatcher:latest
    container_name: mail
    ports:
      - ${PORT_MAIL:-8082}:1080
    expose:
      - 1025
    links:
      - db:db
    networks:
      - laravel-network
    depends_on:
      - db
    healthcheck:
      test: ["CMD", "curl", "--fail", "http://localhost:1080"]
      interval: 5s
      timeout: 5s
      retries: 15
      start_period: 5s
```

Once CURL is installed in the container, `docker-compose ps` will now look like this:
```
        Name                       Command                  State                     Ports              
---------------------------------------------------------------------------------------------------------  
mail         /run.sh                          Up (healthy)   1025/tcp, 0.0.0.0:8082->1080/tcp 
```

Or, when it's starting:
```
        Name                       Command                  State                     Ports              
---------------------------------------------------------------------------------------------------------  
mail         /run.sh                          Up (health: starting)   1025/tcp, 0.0.0.0:8082->1080/tcp 
```